### PR TITLE
Force MAC address retrieval from EEPROM for PicoZed

### DIFF
--- a/configs/project/config.board.pz7010_fmc2.sh
+++ b/configs/project/config.board.pz7010_fmc2.sh
@@ -14,6 +14,9 @@ PETALINUX_PROJECT_HOSTNAME=$(echo $PETALINUX_PROJECT_NAME | sed 's/\_/-/g')
 ${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_SUBSYSTEM_HOSTNAME -v "\"$PETALINUX_PROJECT_HOSTNAME\""
 ${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_USER_LAYER_0 -v "\"\${PROOT}/project-spec/meta-avnet\""
 
+# For PicoZed, an invalid MAC address needs to be set for the MAC address to be fetched from the I2C EEPROM
+${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_SUBSYSTEM_ETHERNET_PS7_ETHERNET_0_MAC -v "\"ff:ff:ff:ff:ff:ff\""
+
 if [ "$PETALINUX_BOARD_PROJECT" == "base" ];
 then
     ${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_YOCTO_MACHINE_NAME -v "\"$BASE_YOCTO_MACHINE\""

--- a/configs/project/config.board.pz7015_fmc2.sh
+++ b/configs/project/config.board.pz7015_fmc2.sh
@@ -14,6 +14,9 @@ PETALINUX_PROJECT_HOSTNAME=$(echo $PETALINUX_PROJECT_NAME | sed 's/\_/-/g')
 ${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_SUBSYSTEM_HOSTNAME -v "\"$PETALINUX_PROJECT_HOSTNAME\""
 ${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_USER_LAYER_0 -v "\"\${PROOT}/project-spec/meta-avnet\""
 
+# For PicoZed, an invalid MAC address needs to be set for the MAC address to be fetched from the I2C EEPROM
+${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_SUBSYSTEM_ETHERNET_PS7_ETHERNET_0_MAC -v "\"ff:ff:ff:ff:ff:ff\""
+
 if [ "$PETALINUX_BOARD_PROJECT" == "base" ];
 then
     ${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_YOCTO_MACHINE_NAME -v "\"$BASE_YOCTO_MACHINE\""

--- a/configs/project/config.board.pz7020_fmc2.sh
+++ b/configs/project/config.board.pz7020_fmc2.sh
@@ -14,6 +14,9 @@ PETALINUX_PROJECT_HOSTNAME=$(echo $PETALINUX_PROJECT_NAME | sed 's/\_/-/g')
 ${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_SUBSYSTEM_HOSTNAME -v "\"$PETALINUX_PROJECT_HOSTNAME\""
 ${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_USER_LAYER_0 -v "\"\${PROOT}/project-spec/meta-avnet\""
 
+# For PicoZed, an invalid MAC address needs to be set for the MAC address to be fetched from the I2C EEPROM
+${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_SUBSYSTEM_ETHERNET_PS7_ETHERNET_0_MAC -v "\"ff:ff:ff:ff:ff:ff\""
+
 if [ "$PETALINUX_BOARD_PROJECT" == "base" ];
 then
     ${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_YOCTO_MACHINE_NAME -v "\"$BASE_YOCTO_MACHINE\""

--- a/configs/project/config.board.pz7030_fmc2.sh
+++ b/configs/project/config.board.pz7030_fmc2.sh
@@ -14,6 +14,9 @@ PETALINUX_PROJECT_HOSTNAME=$(echo $PETALINUX_PROJECT_NAME | sed 's/\_/-/g')
 ${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_SUBSYSTEM_HOSTNAME -v "\"$PETALINUX_PROJECT_HOSTNAME\""
 ${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_USER_LAYER_0 -v "\"\${PROOT}/project-spec/meta-avnet\""
 
+# For PicoZed, an invalid MAC address needs to be set for the MAC address to be fetched from the I2C EEPROM
+${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_SUBSYSTEM_ETHERNET_PS7_ETHERNET_0_MAC -v "\"ff:ff:ff:ff:ff:ff\""
+
 if [ "$PETALINUX_BOARD_PROJECT" == "base" ];
 then
     ${KCONFIG_EDIT} -c ${CONFIG_FILE} -o CONFIG_YOCTO_MACHINE_NAME -v "\"$BASE_YOCTO_MACHINE\""


### PR DESCRIPTION
Petalinux configuration requires an invalid MAC address to be set for automatic MAC address retrieval from the EEPROM in Linux.

This is required for the PicoZed FMC Carrier Board (PZCC-FMC-V2) which has a I2C EEPROM where the MAC address is stored. 

Therefore, the configuration script has been modified to set the MAC address to `FF:FF:FF:FF:FF:FF` in the configuration for each PicoZed board. 