### PR TITLE
zub1cg_sbc_base image scripts and zub1cg QSPI SD card boot script

### DIFF
--- a/documentation/zub1cg/how_to_boot.txt
+++ b/documentation/zub1cg/how_to_boot.txt
@@ -83,14 +83,28 @@ BOOT METHODS:
 
     Reboot the board, and let u-boot automatically load the kernel on the EMMC.
 
-5- Boot from QSPI (u-boot) + eMMC FAT32 (kernel) + eMMC EXT4 (rootfs):
+5- Boot from QSPI (u-boot) + SD card FAT32 (kernel) + SD card INITRD (rootfs):
+
+    After having done the emmc partitioning from method 2, position the 
+    BOOT Switch SW2 on the board to "JTAG" mode (SW[1:4] ON,ON,ON,ON).
+
+    Then to install the bootloaders and mmc boot script on the qspi, run the command:
+
+        sh boot_qspi_mmc.sh
+
+    Position the BOOT Switch SW2 on the board to "QSPI" mode (SW[1:4] ON,OFF,ON,ON).
+
+    Reboot the board. The board will load u-boot from the qspi and then fetch the kernel from SD card.
+
+
+6 - Boot from QSPI (u-boot) + SD card FAT32 (kernel) + SD card EXT4 (rootfs):
 
     After having done the emmc partitioning from method 4, position the 
     BOOT Switch SW2 on the board to "JTAG" mode (SW[1:4] ON,ON,ON,ON).
 
-    Then to install the bootloaders on the qspi, run the command:
+    Then to install the bootloaders and mmc boot script on the qspi, run the command:
 
-        program_flash -f ./BOOT_INITRD_MINIMAL.BIN -offset 0 -flash_type qspi_dual_parallel -fsbl ./images/linux/zynqmp_fsbl.elf
+        sh boot_qspi_mmc.sh
 
     Position the BOOT Switch SW2 on the board to "QSPI" mode (SW[1:4] ON,OFF,ON,ON).
 

--- a/scripts/boot/zub1cg/boot_jtag.tcl
+++ b/scripts/boot/zub1cg/boot_jtag.tcl
@@ -15,11 +15,11 @@
 #  This design is the property of Avnet.  Publication of this
 #  design is not authorized without written consent from Avnet.
 #
-#  Please direct any questions to the UltraZed community support forum:
-#     http://avnet.me/uzegforum and http://avnet.me/uzevforum
+#  Please direct any questions to the ZUBoard community support forum:
+#     http://avnet.me/zuboard-1cg-forum
 #
 #  Product information is available at:
-#     http://avnet.me/ultrazed-eg and http://avnet.me/ultrazed-ev
+#     http://avnet.me/zuboard-1cg
 #
 #  Disclaimer:
 #     Avnet, Inc. makes no warranty for the use of this code or design.

--- a/scripts/boot/zub1cg/boot_jtag_tftp_INITRD.tcl
+++ b/scripts/boot/zub1cg/boot_jtag_tftp_INITRD.tcl
@@ -15,11 +15,11 @@
 #  This design is the property of Avnet.  Publication of this
 #  design is not authorized without written consent from Avnet.
 #
-#  Please direct any questions to the UltraZed community support forum:
-#     http://avnet.me/uzegforum and http://avnet.me/uzevforum
+#  Please direct any questions to the ZUBoard community support forum:
+#     http://avnet.me/zuboard-1cg-forum
 #
 #  Product information is available at:
-#     http://avnet.me/ultrazed-eg and http://avnet.me/ultrazed-ev
+#     http://avnet.me/zuboard-1cg
 #
 #  Disclaimer:
 #     Avnet, Inc. makes no warranty for the use of this code or design.

--- a/scripts/boot/zub1cg/boot_jtag_tftp_dhcp_INITRD.sh
+++ b/scripts/boot/zub1cg/boot_jtag_tftp_dhcp_INITRD.sh
@@ -15,11 +15,11 @@
 #  This design is the property of Avnet.  Publication of this
 #  design is not authorized without written consent from Avnet.
 #
-#  Please direct any questions to the UltraZed community support forum:
-#     http://avnet.me/uzegforum and http://avnet.me/uzevforum
+#  Please direct any questions to the ZUBoard community support forum:
+#     http://avnet.me/zuboard-1cg-forum
 #
 #  Product information is available at:
-#     http://avnet.me/ultrazed-eg and http://avnet.me/ultrazed-ev
+#     http://avnet.me/zuboard-1cg
 #
 #  Disclaimer:
 #     Avnet, Inc. makes no warranty for the use of this code or design.

--- a/scripts/boot/zub1cg/boot_jtag_tftp_dhcp_INITRD.tcl
+++ b/scripts/boot/zub1cg/boot_jtag_tftp_dhcp_INITRD.tcl
@@ -15,11 +15,11 @@
 #  This design is the property of Avnet.  Publication of this
 #  design is not authorized without written consent from Avnet.
 #
-#  Please direct any questions to the UltraZed community support forum:
-#     http://avnet.me/uzegforum and http://avnet.me/uzevforum
+#  Please direct any questions to the ZUBoard community support forum:
+#     http://avnet.me/zuboard-1cg-forum
 #
 #  Product information is available at:
-#     http://avnet.me/ultrazed-eg and http://avnet.me/ultrazed-ev
+#     http://avnet.me/zuboard-1cg
 #
 #  Disclaimer:
 #     Avnet, Inc. makes no warranty for the use of this code or design.

--- a/scripts/boot/zub1cg/boot_qspi_mmc.sh
+++ b/scripts/boot/zub1cg/boot_qspi_mmc.sh
@@ -15,8 +15,6 @@
 #  This design is the property of Avnet.  Publication of this
 #  design is not authorized without written consent from Avnet.
 #
-#  Please direct any questions to the PicoZed community support forum:
-#     http://avnet.me/zub1cg_forum
 #
 #  Product information is available at:
 #     http://avnet.me/zub1cg
@@ -27,18 +25,19 @@
 #     any errors, which may appear in this code, nor does it make a commitment
 #     to update the information contained herein. Avnet, Inc specifically
 #     disclaims any implied warranties of fitness for a particular purpose.
-#                      Copyright(c) 2021 Avnet, Inc.
+#                      Copyright(c) 2022 Avnet, Inc.
 #                              All rights reserved.
 #
 # ----------------------------------------------------------------------------
 #!/bin/bash
 
 # This script will generate a BOOT.BIN file and program the qspi
-# This BOOT.BIN file will contain uboot, a kernel with INITRD and a boot.scr
+# This BOOT.BIN file will contain uboot, a boot.scr script to boot a kernel
+# from a SD/MMC card.
 
 # Stop the script whenever we had an error (non-zero returning function)
 set -e
 
-petalinux-package --boot --fsbl ./images/linux/zynqmp_fsbl.elf --fpga ./images/linux/system.bit --uboot --kernel ./image_INITRD_MINIMAL.ub -o BOOT_LINUX_QSPI.BIN --force --boot-device flash --add ./images/linux/avnet-boot/avnet_qspi.scr --offset 0x1FC0000
+petalinux-package --boot --fsbl ./images/linux/zynqmp_fsbl.elf --fpga ./images/linux/system.bit --uboot -o BOOT_LINUX_MMC_UBOOT_QSPI.BIN --force --boot-device flash --add ./images/linux/avnet-boot/avnet_mmc.scr --offset 0x01e80000
 
-program_flash -f ./BOOT_LINUX_QSPI.BIN -offset 0 -flash_type qspi-x4-single -fsbl ./images/linux/zynqmp_fsbl.elf
+program_flash -f ./BOOT_LINUX_MMC_UBOOT_QSPI.BIN -offset 0 -flash_type qspi-x4-single -fsbl ./images/linux/zynqmp_fsbl.elf

--- a/scripts/boot/zub1cg/boot_qspi_mmc.sh
+++ b/scripts/boot/zub1cg/boot_qspi_mmc.sh
@@ -15,9 +15,11 @@
 #  This design is the property of Avnet.  Publication of this
 #  design is not authorized without written consent from Avnet.
 #
+#  Please direct any questions to the ZUBoard community support forum:
+#     http://avnet.me/zuboard-1cg-forum
 #
 #  Product information is available at:
-#     http://avnet.me/zub1cg
+#     http://avnet.me/zuboard-1cg
 #
 #  Disclaimer:
 #     Avnet, Inc. makes no warranty for the use of this code or design.

--- a/scripts/boot/zub1cg/create_dhcp_boot_scr.sh
+++ b/scripts/boot/zub1cg/create_dhcp_boot_scr.sh
@@ -15,11 +15,11 @@
 #  This design is the property of Avnet.  Publication of this
 #  design is not authorized without written consent from Avnet.
 #
-#  Please direct any questions to the UltraZed community support forum:
-#     http://avnet.me/uzegforum and http://avnet.me/uzevforum
+#  Please direct any questions to the ZUBoard community support forum:
+#     http://avnet.me/zuboard-1cg-forum
 #
 #  Product information is available at:
-#     http://avnet.me/ultrazed-eg and http://avnet.me/ultrazed-ev
+#     http://avnet.me/zuboard-1cg
 #
 #  Disclaimer:
 #     Avnet, Inc. makes no warranty for the use of this code or design.

--- a/scripts/make_zub1cg_sbc_base.sh
+++ b/scripts/make_zub1cg_sbc_base.sh
@@ -1,0 +1,84 @@
+# ----------------------------------------------------------------------------
+#
+#        ** **        **          **  ****      **  **********  ********** ®
+#       **   **        **        **   ** **     **  **              **
+#      **     **        **      **    **  **    **  **              **
+#     **       **        **    **     **   **   **  *********       **
+#    **         **        **  **      **    **  **  **              **
+#   **           **        ****       **     ** **  **              **
+#  **  .........  **        **        **      ****  **********      **
+#     ...........
+#                                     Reach Further™
+#
+# ----------------------------------------------------------------------------
+#
+#  This design is the property of Avnet.  Publication of this
+#  design is not authorized without written consent from Avnet.
+#
+#  Product information is available at:
+#     http://avnet.me/zuboard-1cg
+#
+#  Disclaimer:
+#     Avnet, Inc. makes no warranty for the use of this code or design.
+#     This code is provided  "As Is". Avnet, Inc assumes no responsibility for
+#     any errors, which may appear in this code, nor does it make a commitment
+#     to update the information contained herein. Avnet, Inc specifically
+#     disclaims any implied warranties of fitness for a particular purpose.
+#                      Copyright(c) 2021 Avnet, Inc.
+#                              All rights reserved.
+#
+# ----------------------------------------------------------------------------
+#
+#  Create Date:         Sept 26, 2022
+#  Design Name:         ZUBoard-1CG Base BSP
+#  Module Name:         make_zub1cg_sbc_base.sh
+#  Project Name:        ZUBoard-1CG Base BSP
+#  Target Devices:      Xilinx Zynq UltraScale+ 1CG
+#  Hardware Boards:     ZUBoard-1CG
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+# Stop the script whenever we had an error (non-zero returning function)
+set -e
+
+# MAIN_SCRIPT_FOLDER is the folder where this current script is
+MAIN_SCRIPT_FOLDER=$(realpath $0 | xargs dirname)
+
+FSBL_PROJECT_NAME=zynqmp_fsbl
+
+HDL_PROJECT_NAME=base
+HDL_BOARD_NAME=zub1cg_sbc
+
+ARCH="aarch64"
+SOC="zynqMP"
+
+PETALINUX_BOARD_FAMILY=zub1cg
+PETALINUX_BOARD_NAME=${HDL_BOARD_NAME}
+PETALINUX_BOARD_PROJECT=${HDL_PROJECT_NAME}
+PETALINUX_PROJECT_ROOT_NAME=${PETALINUX_BOARD_NAME}_${PETALINUX_BOARD_PROJECT}
+
+PETALINUX_BUILD_IMAGE=avnet-image-full
+
+KEEP_CACHE="true"
+KEEP_WORK="false"
+DEBUG="no"
+
+#NO_BIT_OPTION can be set to 'yes' to generate a BOOT.BIN without bitstream
+NO_BIT_OPTION='yes'
+
+source ${MAIN_SCRIPT_FOLDER}/common.sh
+
+setup_project
+
+BOOT_METHOD='INITRD'
+BOOT_SUFFIX='_MINIMAL'
+INITRAMFS_IMAGE='avnet-image-minimal'
+build_bsp
+
+BOOT_METHOD='EXT4'
+unset BOOT_SUFFIX
+unset INITRAMFS_IMAGE
+build_bsp
+
+package_bsp

--- a/scripts/make_zub1cg_sbc_base.sh
+++ b/scripts/make_zub1cg_sbc_base.sh
@@ -15,11 +15,11 @@
 #  This design is the property of Avnet.  Publication of this
 #  design is not authorized without written consent from Avnet.
 #
-#  Please direct any questions to the Ultra96 community support forum:
-#     http://avnet.me/Ultra96_Forum
+#  Please direct any questions to the ZUBoard community support forum:
+#     http://avnet.me/zuboard-1cg-forum
 #
 #  Product information is available at:
-#     http://avnet.me/ultra96-v2
+#     http://avnet.me/zuboard-1cg
 #
 #  Disclaimer:
 #     Avnet, Inc. makes no warranty for the use of this code or design.

--- a/scripts/make_zub1cg_sbc_base.sh
+++ b/scripts/make_zub1cg_sbc_base.sh
@@ -15,8 +15,11 @@
 #  This design is the property of Avnet.  Publication of this
 #  design is not authorized without written consent from Avnet.
 #
+#  Please direct any questions to the Ultra96 community support forum:
+#     http://avnet.me/Ultra96_Forum
+#
 #  Product information is available at:
-#     http://avnet.me/zuboard-1cg
+#     http://avnet.me/ultra96-v2
 #
 #  Disclaimer:
 #     Avnet, Inc. makes no warranty for the use of this code or design.

--- a/scripts/make_zub1cg_sbc_dualcam.sh
+++ b/scripts/make_zub1cg_sbc_dualcam.sh
@@ -15,11 +15,11 @@
 #  This design is the property of Avnet.  Publication of this
 #  design is not authorized without written consent from Avnet.
 #
-#  Please direct any questions to the Ultra96 community support forum:
-#     http://avnet.me/Ultra96_Forum
+#  Please direct any questions to the ZUBoard community support forum:
+#     http://avnet.me/zuboard-1cg-forum
 #
 #  Product information is available at:
-#     http://avnet.me/ultra96-v2
+#     http://avnet.me/zuboard-1cg
 #
 #  Disclaimer:
 #     Avnet, Inc. makes no warranty for the use of this code or design.
@@ -33,11 +33,11 @@
 # ----------------------------------------------------------------------------
 #
 #  Create Date:         Mar 11, 2022
-#  Design Name:         XBZU1 Dualcam BSP
+#  Design Name:         ZUBoard-1CG Dualcam BSP
 #  Module Name:         make_zub1cg_sbc_dualcam.sh
-#  Project Name:        XBZU1 Dualcam BSP
+#  Project Name:        ZUBoard-1CG Dualcam BSP
 #  Target Devices:      Xilinx Zynq UltraScale+ 1CG
-#  Hardware Boards:     XBZU1 Board
+#  Hardware Boards:     ZUBoard-1CG Board
 #
 # ----------------------------------------------------------------------------
 

--- a/scripts/make_zub1cg_sbc_factest.sh
+++ b/scripts/make_zub1cg_sbc_factest.sh
@@ -15,11 +15,11 @@
 #  This design is the property of Avnet.  Publication of this
 #  design is not authorized without written consent from Avnet.
 #
-#  Please direct any questions to the Ultra96 community support forum:
-#     http://avnet.me/Ultra96_Forum
+#  Please direct any questions to the ZUBoard community support forum:
+#     http://avnet.me/zuboard-1cg-forum
 #
 #  Product information is available at:
-#     http://avnet.me/ultra96-v2
+#     http://avnet.me/zuboard-1cg
 #
 #  Disclaimer:
 #     Avnet, Inc. makes no warranty for the use of this code or design.
@@ -33,11 +33,11 @@
 # ----------------------------------------------------------------------------
 #
 #  Create Date:         Mar 11, 2022
-#  Design Name:         XBZU1 Factory Acceptance Test BSP
+#  Design Name:         ZUBoard-1CG Factory Acceptance Test BSP
 #  Module Name:         make_zub1cg_sbc_factest.sh
-#  Project Name:        XBZU1 Factory Acceptance Test BSP
+#  Project Name:        ZUBoard-1CG Factory Acceptance Test BSP
 #  Target Devices:      Xilinx Zynq UltraScale+ 1CG
-#  Hardware Boards:     XBZU1 Board
+#  Hardware Boards:     ZUBoard-1CG Board
 #
 # ----------------------------------------------------------------------------
 

--- a/scripts/make_zub1cg_sbc_valtest.sh
+++ b/scripts/make_zub1cg_sbc_valtest.sh
@@ -15,11 +15,11 @@
 #  This design is the property of Avnet.  Publication of this
 #  design is not authorized without written consent from Avnet.
 #
-#  Please direct any questions to the Ultra96 community support forum:
-#     http://avnet.me/Ultra96_Forum
+#  Please direct any questions to the ZUBoard community support forum:
+#     http://avnet.me/zuboard-1cg-forum
 #
 #  Product information is available at:
-#     http://avnet.me/ultra96-v2
+#     http://avnet.me/zuboard-1cg
 #
 #  Disclaimer:
 #     Avnet, Inc. makes no warranty for the use of this code or design.
@@ -33,11 +33,11 @@
 # ----------------------------------------------------------------------------
 #
 #  Create Date:         Mar 11, 2022
-#  Design Name:         XBZU1 Validation Test BSP
+#  Design Name:         ZUBoard-1CG Validation Test BSP
 #  Module Name:         make_zub1cg_sbc_valtest.sh
-#  Project Name:        XBZU1 Validation Test BSP
+#  Project Name:        ZUBoard-1CG Validation Test BSP
 #  Target Devices:      Xilinx Zynq UltraScale+ 1CG
-#  Hardware Boards:     XBZU1 Board
+#  Hardware Boards:     ZUBoard-1CG Board
 #
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Added `zub1cg_sbc_base` image scripts to allow for building of a base image. 

Using the `boot_qspi_mmc.sh` script, a QSPI image is created with: a FSBL and U-Boot (_Kernel image excluded due to size being to large for QSPI.)

When this script combined is combined with a small change to the address of where U-Boot looks for the boot script when booting from the QSPI, means that we can boot from both a INITD and a EXT4 kernel/rootfs images stored on the SD card.